### PR TITLE
refactor: cleanup graph utilities and fix search limit parameter

### DIFF
--- a/src/shared_memory/core/graph.py
+++ b/src/shared_memory/core/graph.py
@@ -29,6 +29,7 @@ async def extract_hashtags(content: str) -> list[str]:
 
         prompt = (
             "Extract up to 5 highly relevant keywords or hashtags from the following text. "
+            "Normalize them to lowercase and remove spaces within tags. "
             "Output MUST be a JSON list of strings (e.g. ['#python', '#mcp']).\n\n"
             f"TEXT:\n{content}"
         )
@@ -44,7 +45,8 @@ async def extract_hashtags(content: str) -> list[str]:
             # Clean and normalize tags
             cleaned = []
             for t_raw in tags:
-                t_clean = str(t_raw).strip().lower()
+                # Normalize: lowercase, ensure starts with #, no spaces
+                t_clean = str(t_raw).strip().lower().replace(" ", "")
                 if not t_clean.startswith("#"):
                     t_clean = f"#{t_clean}"
                 if len(t_clean) > 1:
@@ -56,18 +58,28 @@ async def extract_hashtags(content: str) -> list[str]:
         return []
 
 
-async def save_tags(
-    content_id: str, content_type: str, tags: list[str], conn
-):
-    """Saves tags to the database."""
+async def save_tags(content_id: str, content_type: str, tags: list[str], conn):
+    """
+    Saves tags for a piece of knowledge in the tags table.
+    Deletes existing tags for the content first to ensure a clean refresh.
+    """
     if not tags:
         return
 
-    data = [(t, content_id, content_type) for t in tags]
-    await conn.executemany(
-        "INSERT OR IGNORE INTO tags (tag, content_id, content_type) VALUES (?, ?, ?)",
-        data
-    )
+    try:
+        # 1. Delete old tags
+        await conn.execute(
+            "DELETE FROM tags WHERE content_id = ? AND content_type = ?",
+            (content_id, content_type)
+        )
+        # 2. Insert new tags
+        data = [(t, content_id, content_type) for t in tags]
+        await conn.executemany(
+            "INSERT OR IGNORE INTO tags (tag, content_id, content_type) VALUES (?, ?, ?)",
+            data
+        )
+    except Exception as e:
+        logger.error(f"Failed to save tags for {content_id}: {e}")
 
 
 async def check_conflict(entity_name: str, new_contents: list[str], agent_id: str, conn=None):
@@ -180,65 +192,6 @@ async def _check_conflicts_internal(
     return final_results
 
 
-async def extract_hashtags(content: str) -> list[str]:
-    """
-    Extracts hashtags from the given content using AI.
-    Returns a list of hashtags like ['#python', '#mcp'].
-    """
-    if not content or len(content) < 10:
-        return []
-
-    client = get_gemini_client()
-    prompt = (
-        "Extract up to 5 important keywords or concepts from the following text and return them as hashtags. "
-        "Normalize them to lowercase and remove spaces within tags. "
-        "Return ONLY a JSON list of strings. "
-        f"Text: {content}"
-    )
-
-    try:
-        response = await client.aio.models.generate_content(
-            model="gemini-2.0-flash-exp",
-            contents=prompt,
-            config={"response_mime_type": "application/json"}
-        )
-        tags = json.loads(response.text)
-        if isinstance(tags, list):
-            # Normalize: lowercase, ensure starts with #, no spaces
-            normalized = []
-            for t in tags:
-                t = t.strip().lower().replace(" ", "")
-                if not t.startswith("#"):
-                    t = f"#{t}"
-                normalized.append(t)
-            return normalized[:5]
-    except Exception as e:
-        get_logger("graph").debug(f"Hashtag extraction failed: {e}")
-
-    return []
-
-
-async def save_tags(content_id: str, content_type: str, tags: list[str], conn):
-    """
-    Saves tags for a piece of knowledge in the tags table.
-    """
-    if not tags:
-        return
-
-    try:
-        # Delete old tags first
-        await conn.execute(
-            "DELETE FROM tags WHERE content_id = ? AND content_type = ?",
-            (content_id, content_type)
-        )
-        # Insert new tags
-        for tag in tags:
-            await conn.execute(
-                "INSERT INTO tags (tag, content_id, content_type) VALUES (?, ?, ?)",
-                (tag, content_id, content_type)
-            )
-    except Exception as e:
-        get_logger("graph").error(f"Failed to save tags for {content_id}: {e}")
 
 
 async def search_by_tags(tags: list[str], conn) -> list[str]:

--- a/src/shared_memory/core/search.py
+++ b/src/shared_memory/core/search.py
@@ -188,7 +188,8 @@ async def perform_search(query: str, limit: int = 10, candidate_limit: int = 20)
                     results.append((cid, final_score))
 
             results.sort(key=lambda x: x[1], reverse=True)
-            top_results = [r for r in results[:candidate_limit] if r[1] > 0.05]
+            # Step 5: Respect the limit and filter by threshold
+            top_results = [r for r in results[:limit] if r[1] > 0.05]
             top_cids = [r[0] for r in top_results]
 
             # Update access for top results


### PR DESCRIPTION
Closes #16

This PR cleans up redundant code and fixes the search limit parameter issue:
- **`graph.py`**: Removed duplicate `extract_hashtags` and `save_tags` functions. Consolidated logic to use centralized settings and rate limiting.
- **`search.py`**: Fixed `perform_search` to respect the `limit` parameter for final results, improving performance by fetching detailed data only for requested items.

Verified with 24 unit tests passing.