### PR TITLE
fix: sanitize FTS5 search query (#26)

### DIFF
--- a/src/shared_memory/core/search.py
+++ b/src/shared_memory/core/search.py
@@ -25,6 +25,22 @@ from shared_memory.infra.embeddings import (
 logger = get_logger("search")
 
 
+def sanitize_fts_query(query: str) -> str:
+    """
+    Sanitizes a query string for FTS5 MATCH clause.
+    Extracts alphanumeric words and wraps them in double quotes to prevent
+    special characters (like hyphens) from being interpreted as operators.
+    """
+    if not query:
+        return ""
+    # Extract words (supporting Unicode)
+    words = re.findall(r"\w+", query)
+    if not words:
+        return ""
+    # Join with spaces, wrapping each in double quotes
+    return " ".join(f'"{w}"' for w in words)
+
+
 async def perform_keyword_search(query: str, limit: int = 5, exclude_session_id: str = None):
     """
     Improved Keyword Search Logic:
@@ -44,13 +60,18 @@ async def perform_keyword_search(query: str, limit: int = 5, exclude_session_id:
             ("bank_files_fts", "bank_files", "filename", "content"),
         ]
 
+        # Sanitize query for FTS5
+        safe_query = sanitize_fts_query(query)
+
         for fts_table, source_name, id_col, content_col in fts_sources:
+            if not safe_query:
+                break
             try:
                 # Use MATCH for fast full-text searching and BM25 for ranking
                 cursor = await conn.execute(
                     f"SELECT {id_col}, {content_col}, bm25({fts_table}) "
                     f"FROM {fts_table} WHERE {fts_table} MATCH ?",
-                    (query,)
+                    (safe_query,)
                 )
                 for row_id, content, rank in await cursor.fetchall():
                     # BM25 returns smaller values for better matches; 
@@ -91,13 +112,14 @@ async def perform_keyword_search(query: str, limit: int = 5, exclude_session_id:
 
         # 2. Search Thoughts DB using FTS5
         try:
-            async with await async_get_thoughts_connection() as t_conn:
-                t_cursor = await t_conn.execute(
-                    "SELECT session_id, thought_number, thought, bm25(thought_history_fts) "
-                    "FROM thought_history_fts WHERE thought_history_fts MATCH ? "
-                    "AND session_id != ?",
-                    (query, exclude_session_id or ""),
-                )
+            if safe_query:
+                async with await async_get_thoughts_connection() as t_conn:
+                    t_cursor = await t_conn.execute(
+                        "SELECT session_id, thought_number, thought, bm25(thought_history_fts) "
+                        "FROM thought_history_fts WHERE thought_history_fts MATCH ? "
+                        "AND session_id != ?",
+                        (safe_query, exclude_session_id or ""),
+                    )
                 for sess_id, t_num, thought, rank in await t_cursor.fetchall():
                     score = max(0.1, abs(rank) * 1.0)
                     key = ("thought_history", f"{sess_id}#{t_num}")

--- a/tests/unit/test_search_sanitization.py
+++ b/tests/unit/test_search_sanitization.py
@@ -1,0 +1,31 @@
+import pytest
+from shared_memory.core.search import sanitize_fts_query
+
+def test_sanitize_fts_query_basic():
+    assert sanitize_fts_query("hello world") == '"hello" "world"'
+
+def test_sanitize_fts_query_hyphen():
+    # This was the problematic case
+    assert sanitize_fts_query("trade-off") == '"trade" "off"'
+
+def test_sanitize_fts_query_special_chars():
+    assert sanitize_fts_query("hello @world #tag!") == '"hello" "world" "tag"'
+
+def test_sanitize_fts_query_japanese():
+    # Ensure it works with Japanese characters (which \w supports in Python 3)
+    assert sanitize_fts_query("こんにちは 世界") == '"こんにちは" "世界"'
+
+def test_sanitize_fts_query_empty():
+    assert sanitize_fts_query("") == ""
+    assert sanitize_fts_query("   ") == ""
+    assert sanitize_fts_query("!!!") == ""
+
+@pytest.mark.asyncio
+async def test_perform_keyword_search_with_hyphen(fake_llm):
+    # This test ensures that perform_keyword_search doesn't crash with hyphens.
+    from shared_memory.core.search import perform_keyword_search
+    
+    # Even if no data is found, it should NOT raise OperationalError
+    # setup_teardown_db (autouse) handles the DB initialization.
+    results = await perform_keyword_search("trade-off")
+    assert isinstance(results, list)


### PR DESCRIPTION
This PR fixes the `OperationalError: no such column: off` error reported in issue #26.

### Changes:
- Added `sanitize_fts_query` helper to `search.py` to wrap search terms in double quotes.
- Updated `perform_keyword_search` to use the sanitized query for FTS5 `MATCH` clauses.
- Added unit tests in `tests/unit/test_search_sanitization.py`.

Closes #26