### PR TITLE
fix: release output condition and CLA agreement

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,18 +71,28 @@ jobs:
         with:
           python-version: '3.11'
           enable-cache: true
-      - name: Install semantic-release
-        run: |
-          if [ ! -d ".venv" ]; then uv venv; fi
-          ls -la
-          uv pip install python-semantic-release
-      - name: Python Semantic Release
+      - name: Install and Run Semantic Release
         id: semantic
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [ ! -d ".venv" ]; then uv venv; fi
+          uv pip install python-semantic-release
+          
+          PREV_VER=$(uv run semantic-release version --print)
+          echo "Previous version: $PREV_VER"
+          
           uv run semantic-release version
-          uv run semantic-release publish
+          
+          NEW_VER=$(uv run semantic-release version --print)
+          echo "New version: $NEW_VER"
+          
+          if [ "$PREV_VER" != "$NEW_VER" ]; then
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            uv run semantic-release publish
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+          fi
 
   build_assets:
     name: Build Windows Assets

--- a/CLA.md
+++ b/CLA.md
@@ -1,40 +1,91 @@
 # Contributor License Agreement (CLA)
 
-**Project**: Ripen  
+**Project**: Ripen
 **Owner**: Ayato-Labs (hereinafter "Owner")
+**Effective Date**: 2026-05-16
+**Version**: 2.0
 
-Thank you for your interest in contributing to Ripen. To protect the project and its users, we require all contributors to agree to this CLA.
+Thank you for your interest in contributing to Ripen. This Contributor License Agreement ("Agreement") clarifies the intellectual property rights granted with Contributions from any person or entity. To protect both you and the Owner, we require all contributors to indicate agreement with this CLA.
+
+> [!IMPORTANT]
+> This document is NOT a substitute for professional legal advice. While it has been drafted referencing industry-standard CLAs (Apache ICLA, MongoDB CLA), the Owner strongly recommends that contributors with concerns consult their own legal counsel before agreeing.
 
 ---
 
 ## 1. Definitions
 
-"Contribution" means any code, documentation, or other artifacts submitted by you to the Owner for inclusion in the project.
+- **"You" (or "Your")** means the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with the Owner. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor.
+- **"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Owner for inclusion in, or documentation of, the Project. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Owner or its representatives, including but not limited to Pull Requests, patches, issues, and comments on GitHub.
+- **"Project"** means the Ripen software project as maintained and distributed by the Owner, including all source code, documentation, and associated materials in the `ayato-labs/ripen` repository and any derivative or successor projects.
 
 ## 2. Grant of Copyright License
 
-You hereby grant to the Owner a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works.
+Subject to the terms and conditions of this Agreement, You hereby grant to the Owner a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable** copyright license to:
 
-## 3. Assignment of Rights (Dual-Licensing Consent)
+- reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
 
-You acknowledge and agree that the Owner may distribute the project, including your Contributions, under multiple licenses simultaneously, including but not limited to:
-- The GNU Affero General Public License v3.0 (AGPL-3.0)
-- Proprietary Commercial Licenses
+**Retention of Rights**: You retain all right, title, and interest in and to Your Contributions. Nothing in this Agreement requires You to provide support for Your Contributions, except to the extent You desire to provide support. You are free to use Your Contributions independently for any purpose, including in other projects, whether open-source or proprietary.
 
-You agree that the Owner has the sole right to sell commercial licenses for the software containing your Contributions.
+## 3. Grant of Patent License
 
-## 4. Representations
+Subject to the terms and conditions of this Agreement, You hereby grant to the Owner a **perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable** (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Project, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Project to which such Contribution(s) was submitted.
 
-You represent that:
-- You are legally entitled to grant these licenses.
-- Each of your Contributions is your original creation.
-- Your Contribution does not infringe any third-party intellectual property rights.
+If any entity institutes patent litigation against You or any other entity (including a cross-claim or counterclaim in a lawsuit) alleging that Your Contribution, or the Project to which You have contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Project shall terminate as of the date such litigation is filed.
 
-## 5. Acceptance
+## 4. Dual-Licensing Consent
 
-By submitting a Pull Request to this repository, you agree to the terms of this CLA. Please include the following statement in your PR description:
+You acknowledge that the Project is distributed under a dual-licensing model:
 
-> I have read and agree to the CLA for Ripen.
+- **Open Source**: GNU Affero General Public License v3.0 (AGPL-3.0)
+- **Commercial**: Proprietary Commercial Licenses (as described in `COMMERCIAL.md`)
+
+You agree that the Owner has the exclusive right to offer and sell commercial licenses for **the Project as a whole** (i.e., the combined work containing Your Contributions along with other components of the Project). This right does not restrict Your ability to use, license, or sell Your own Contributions independently, whether as standalone works or as part of other projects unrelated to Ripen.
+
+## 5. Representations and Warranties
+
+You represent and warrant that:
+
+- **(a) Authority**: You are legally entitled to grant the above licenses. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions to the Project, or that Your employer has executed a separate corporate CLA with the Owner.
+- **(b) Originality**: Each of Your Contributions is Your original creation (see Section 7 for submissions on behalf of others).
+- **(c) Non-infringement**: Your Contribution does not, to the best of Your knowledge, infringe any third-party intellectual property rights (including patents, copyrights, and trade secrets).
+- **(d) No Conflicts**: You are not aware of any claims, liens, or encumbrances on the Contributions that would conflict with the licenses granted herein.
+
+## 6. Disclaimer of Warranty
+
+EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 5, YOUR CONTRIBUTIONS ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Submissions on Behalf of Others
+
+Should You wish to submit work that is not Your original creation, You may submit it to the Project separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which You are personally aware, and conspicuously marking the work as:
+
+> "Submitted on behalf of a third-party: [named here]"
+
+## 8. Notification of Changes
+
+You agree to notify the Owner of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.
+
+## 9. Governing Law
+
+This Agreement shall be governed by and construed in accordance with the laws of **Japan**, without regard to its conflict of laws provisions. Any disputes arising under this Agreement shall be resolved in the courts of Tokyo, Japan.
+
+## 10. Acceptance
+
+By submitting a Pull Request to this repository, You agree to the terms of this CLA. Please include the following statement in Your PR description:
+
+> I have read and agree to the [CLA](CLA.md) for Ripen.
 
 ---
-*This CLA ensures that the project remains sustainable and commercially viable while staying open-source.*
+
+> [!NOTE]
+> **Changes from v1.0 (2026-05-16)**:
+> - Added patent license grant (Section 3)
+> - Clarified dual-licensing scope to "Project as a whole" (Section 4)
+> - Added employer/third-party IP representation (Section 5a)
+> - Added disclaimer of warranty (Section 6)
+> - Added third-party submission procedure (Section 7)
+> - Added governing law (Section 9)
+> - Retained contributor's right to independently use their own Contributions
+
+*This CLA ensures that the project remains sustainable and commercially viable while staying open-source, and that contributors are treated fairly.*
+
+*Copyright (C) 2026 Ayato-Labs. All rights reserved.*


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR includes the fix for the release output condition in `main.yml` that was pushed after PR #76 was merged.
It ensures that the `.exe` build is not skipped when a new release is published.