### PR TITLE
chore: add semantic-release configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,3 +137,9 @@ markers = [
     "chaos: Chaos/Failure tests",
 ]
 asyncio_default_fixture_loop_scope = "function"
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+upload_to_PyPI = false
+upload_to_release = true


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR adds the missing `[tool.semantic_release]` configuration to `pyproject.toml`.
This should fix the issue where the `.exe` build is skipped because `semantic-release` didn't detect the `main` branch or version updates.