### PR TITLE
fix: use git tag to detect release in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,15 +79,9 @@ jobs:
           if [ ! -d ".venv" ]; then uv venv; fi
           uv pip install python-semantic-release
           
-          PREV_VER=$(uv run semantic-release version --print)
-          echo "Previous version: $PREV_VER"
-          
           uv run semantic-release version
           
-          NEW_VER=$(uv run semantic-release version --print)
-          echo "New version: $NEW_VER"
-          
-          if [ "$PREV_VER" != "$NEW_VER" ]; then
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
             echo "new_release_published=true" >> $GITHUB_OUTPUT
             uv run semantic-release publish
           else


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR fixes the release detection logic in `main.yml`.
Instead of comparing versions (which failed because `--print` calculates the next version and didn't change before/after), it now checks if a new git tag was actually created on the current commit!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation by simplifying the release detection mechanism in the continuous integration pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayato-labs/ripen/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->