### PR TITLE
fix: pass PAT_TOKEN to checkout step to allow git push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR fixes the Git push failure during `semantic-release`.
By default, the `actions/checkout` step configures Git to use the standard `GITHUB_TOKEN`, which overrides the `GH_TOKEN` environment variable when `python-semantic-release` executes `git push`.
This PR explicitly passes `PAT_TOKEN` to the `actions/checkout` step so that the local Git config is correctly authenticated with the bypass privileges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration for improved release workflow reliability.

**Note:** This release contains only internal infrastructure updates with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayato-labs/ripen/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->