### PR TITLE
fix: trigger release v1.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,4 +144,4 @@ branch = "main"
 upload_to_PyPI = false
 upload_to_release = true
 
-# Trigger release with clean state
+# Trigger release v1.8.1


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR is a dummy change to trigger a release workflow run on `main`.
It updates a comment in `pyproject.toml`.
Since we forced the tag `v1.8.0` on `main`, this PR should result in `v1.8.1` being released!