### PR TITLE
fix: correct PyInstaller script paths in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,8 +116,8 @@ jobs:
           uv pip install pyinstaller
       - name: Build with PyInstaller
         run: |
-          uv run pyinstaller --onefile --name Ripen --clean src/ripen/server.py
-          uv run pyinstaller --onefile --name SharedMemoryRegister --clean src/ripen/register.py
+          uv run pyinstaller --onefile --name Ripen --clean src/ripen/api/server.py
+          uv run pyinstaller --onefile --name SharedMemoryRegister --clean src/ripen/cli/register.py
       - name: Upload Binaries to Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR fixes the PyInstaller build failure in the release workflow.
The previous configuration pointed to `src/ripen/server.py` and `src/ripen/register.py`, but the actual files are located at `src/ripen/api/server.py` and `src/ripen/cli/register.py`.
This PR updates the paths to point to the correct locations!