### PR TITLE
fix: pass tag_name explicitly to action-gh-release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,15 +118,22 @@ jobs:
         run: |
           uv run pyinstaller --onefile --name Ripen --clean src/ripen/api/server.py
           uv run pyinstaller --onefile --name SharedMemoryRegister --clean src/ripen/cli/register.py
+      - name: Get Latest Tag
+        id: tag
+        shell: bash
+        run: |
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Upload Binaries to Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/Ripen.exe
             dist/SharedMemoryRegister.exe
-          # If a tag was just created, it will be used. 
-          # If not, it will try to use the current commit's tag if any.
+          tag_name: ${{ steps.tag.outputs.tag }}
           fail_on_unmatched_files: false
           append_body: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR fixes the "GitHub Releases requires a tag" error in the `build_assets` job.
The `softprops/action-gh-release` action requires a tag to know which release to upload assets to. Since the workflow is triggered by a push to `main` (not a tag push), the action couldn't automatically detect the tag.
This PR adds a step to fetch the latest tag using `git describe` and passes it explicitly to the action!