### PR TITLE
fix: remove duplicate env block in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,5 +135,3 @@ jobs:
           append_body: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR fixes the `Invalid workflow file` error caused by a duplicate `env:` block in `main.yml` (Line 138).
I accidentally duplicated the `env:` block when applying the previous fix. This PR removes the duplicate block and ensures the file is valid YAML!