### PR TITLE
fix: use PAT_TOKEN for Docker login (after PR #87 merge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PAT_TOKEN }}
       - name: Get Latest Tag
         id: tag
         shell: bash


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR adds the fix for the Docker login permission error that occurred in PR #87.
Since PR #87 was merged before I could push this fix to it, I am creating this new PR to apply the fix to `main`!
It changes `GITHUB_TOKEN` to `PAT_TOKEN` in the Docker login step.