### PR TITLE
feat: log version at startup and expand Docker docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,29 @@ Ripen prioritizes **system stability** over massive internal dependencies.
 
 ### Option A: Docker (Recommended for Engineers) 🐳
 The most stable and easiest way to run the Ripen Hub. No Python required. Works on Windows, Mac, and Linux.
+
+#### 1. Install (取得)
 ```bash
-docker run -d -p 8377:8377 -v ripen_data:/data ghcr.io/ayato-labs/ripen:latest
+docker pull ghcr.io/ayato-labs/ripen:latest
+```
+
+#### 2. Start (起動)
+Run the container in the background. We recommend naming it `ripen-hub` for easy management.
+```bash
+docker run -d --name ripen-hub -p 8377:8377 -v ripen_data:/data ghcr.io/ayato-labs/ripen:latest
+```
+
+#### 3. Uninstall (削除)
+To completely remove the container, image, and persisted data:
+```bash
+# Stop and remove the container
+docker stop ripen-hub && docker rm ripen-hub
+
+# Remove the image
+docker rmi ghcr.io/ayato-labs/ripen:latest
+
+# Remove the volume (WARNING: This will delete all your stored knowledge!)
+docker volume rm ripen_data
 ```
 
 ### Option B: Native Binary (Windows Only) 🚀

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -310,7 +310,12 @@ def print_banner(mode: str, port: int):
 
 def main():
     configure_logging()
-    logger.info("--- SERVER SCRIPT STARTING (Extreme Guard Mode) ---")
+    import importlib.metadata
+    try:
+        version = importlib.metadata.version("ripen")
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    logger.info(f"--- SERVER SCRIPT STARTING (Version: {version}) ---")
     logger.info(f"Main execution started (Args: {sys.argv})")
 
 


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR adds the following features as requested:
1. Logs the Ripen version at the very beginning of the server startup (using `importlib.metadata`).
2. Expands the Docker section in README.md to include Install, Start, and Uninstall steps, making it a complete guide for engineers.