### PR TITLE
fix: resolve Ruff import sorting error in server.py

### DIFF
--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -16,6 +16,7 @@ if CURRENT_SRC not in sys.path:
 from fastmcp import FastMCP
 
 # Import project modules
+from ripen.api import dashboard
 from ripen.api.licensing import LicenseManager
 from ripen.common.config import settings
 from ripen.common.plugins import PluginLoader
@@ -37,7 +38,6 @@ from ripen.core import (
     logic as logic_module,
     thought_logic as thought_module,
 )
-from ripen.api import dashboard
 
 # --- INITIALIZATION ---
 logger = get_logger("server")


### PR DESCRIPTION
I have read and agree to the CLA for Ripen.

## Summary
This PR fixes the Ruff lint error `I001 [*] Import block is un-sorted or un-formatted` in `src/ripen/api/server.py` by moving the `dashboard` import to the correct alphabetical position.