### PR TITLE
feat: Support configurable bind address and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Ripen Environment Variables Example
+
+# LLM Provider (gemini, openai, ollama, etc.)
+LLM_PROVIDER=gemini
+
+# API Key for the chosen provider
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# Bind Address for Docker Compose
+# 127.0.0.1 = Localhost only (Secure, Default)
+# 0.0.0.0 = Accessible from other machines in the LAN (Team Use)
+RIPEN_BIND_ADDRESS=127.0.0.1
+
+# Log Level (DEBUG, INFO, WARNING, ERROR)
+LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -59,11 +59,26 @@ Ripen operates purely as a centralized Hub. You host it once, and all your agent
 3. Run `ripen-hub.exe`. It will start the Streamable HTTP server on port `8377`.
 
 ### 2. Connect Your Agents
-Configure your AI agents to connect to the Hub's MCP endpoint: `http://localhost:8377/mcp` (or replace `localhost` with the Hub machine's IP address for team use).
+Configure your AI agents to connect to the Hub's MCP endpoint.
 
-*   **For Cursor / Windsurf / Any SSE Client**:
-    *   Add an MCP server of type `sse` (or "SSE", "Streamable HTTP").
-    *   URL: `http://localhost:8377/mcp`
+*   **For Cursor (Highly Recommended)**:
+    Add a new MCP server in Cursor settings with the following configuration:
+    - **Type**: `streamableHttp`
+    - **URL**: `http://localhost:8377/mcp`
+
+    Or directly edit your `mcp_config.json`:
+    ```json
+    "Ripen": {
+      "type": "streamableHttp",
+      "serverURL": "http://localhost:8377/mcp"
+    }
+    ```
+
+*   **For Team Use (Remote Connection)**:
+    If you are connecting from a different machine (Child PC) to a shared Hub (Parent PC), replace `localhost` with the Parent PC's actual IP address:
+    - **URL**: `http://<Parent_PC_IP>:8377/mcp`
+    
+    *Note: The Docker container is configured to listen on `0.0.0.0`, meaning it accepts connections from any IP address reaching the host machine.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Configure your AI agents to connect to the Hub's MCP endpoint.
     - **Type**: `streamableHttp`
     - **URL**: `http://localhost:8377/mcp`
 
-    Or directly edit your `mcp_config.json`:
+    Or, if you prefer editing the configuration file (e.g., `mcp_config.json` or `mcp.json` depending on the tool) directly, add the following entry to your `"mcpServers"` section:
     ```json
     "Ripen": {
       "type": "streamableHttp",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   ripen:
     image: ghcr.io/ayato-labs/ripen:latest
     ports:
-      - "8377:8377"
+      - "${RIPEN_BIND_ADDRESS:-127.0.0.1}:8377:8377"
     volumes:
       - ripen_data:/data
     environment:


### PR DESCRIPTION
Resolves #103.

This PR adds support for configuring the bind address in `docker-compose.yml` via the `RIPEN_BIND_ADDRESS` environment variable (defaulting to `127.0.0.1` for security). It also adds a `.env.example` file to help new users get started easily.