### PR TITLE
fix: Enhance PyInstaller build logic to include native dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,8 +116,8 @@ jobs:
           uv pip install pyinstaller
       - name: Build with PyInstaller
         run: |
-          uv run pyinstaller --onefile --name Ripen --copy-metadata fastmcp --copy-metadata ripen --clean src/ripen/api/server.py
-          uv run pyinstaller --onefile --name RipenInstaller --copy-metadata fastmcp --copy-metadata ripen --clean src/ripen/cli/register.py
+          uv run pyinstaller --onefile --name Ripen --copy-metadata fastmcp --copy-metadata ripen --collect-all fastembed --collect-all faiss --clean src/ripen/api/server.py
+          uv run pyinstaller --onefile --name RipenInstaller --copy-metadata fastmcp --copy-metadata ripen --collect-all fastembed --collect-all faiss --clean src/ripen/cli/register.py
       - name: Get Latest Tag
         id: tag
         shell: bash


### PR DESCRIPTION
Resolves #105.

This PR enhances the PyInstaller build commands in `main.yml` by adding `--collect-all fastembed` and `--collect-all faiss`. This ensures that native binaries and data files required by these libraries are fully included in the standalone `.exe` files.