### PR TITLE
feat: Build enterprise-grade CI/CD pipeline with multi-OS integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,3 +166,107 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ steps.tag.outputs.tag }}
+
+  test_linux:
+    name: Integration Test (Linux Docker)
+    needs: build_docker
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Replace image in docker-compose.yml
+        run: |
+          sed -i 's|ghcr.io/ayato-labs/ripen:latest|ghcr.io/${{ github.repository }}:latest|' docker-compose.yml
+      - name: Start container
+        run: docker compose up -d
+      - name: Wait for Health Check
+        run: |
+          timeout=30
+          while [ $timeout -gt 0 ]; do
+            if curl -s http://localhost:8377/api/health | grep -q "ok"; then
+              echo "Server is healthy!"
+              exit 0
+            fi
+            sleep 1
+            timeout=$((timeout-1))
+          done
+          echo "Timeout waiting for health check"
+          exit 1
+      - name: Stop container
+        if: always()
+        run: docker compose down
+
+  test_windows:
+    name: Integration Test (Windows Docker)
+    needs: build_docker
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.new_release_published == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Replace image in docker-compose.yml
+        shell: pwsh
+        run: |
+          (Get-Content docker-compose.yml) -replace 'ghcr.io/ayato-labs/ripen:latest', 'ghcr.io/${{ github.repository }}:latest' | Set-Content docker-compose.yml
+      - name: Start container
+        run: docker compose up -d
+      - name: Wait for Health Check
+        shell: pwsh
+        run: |
+          $timeout = 30
+          while ($timeout -gt 0) {
+            try {
+              $response = Invoke-WebRequest -Uri http://localhost:8377/api/health -UseBasicParsing
+              if ($response.Content -match "ok") {
+                Write-Host "Server is healthy!"
+                exit 0
+              }
+            } catch {
+              # Ignore errors during startup
+            }
+            Start-Sleep -Seconds 1
+            $timeout--
+          }
+          Write-Error "Timeout waiting for health check"
+          exit 1
+      - name: Stop container
+        if: always()
+        run: docker compose down
+
+  test_macos:
+    name: Integration Test (macOS Native)
+    needs: build_docker
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.new_release_published == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.11'
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Start server
+        run: |
+          uv run python src/ripen/api/server.py &
+          echo "SERVER_PID=$!" >> $GITHUB_ENV
+      - name: Wait for Health Check
+        run: |
+          timeout=30
+          while [ $timeout -gt 0 ]; do
+            if curl -s http://localhost:8377/api/health | grep -q "ok"; then
+              echo "Server is healthy!"
+              exit 0
+            fi
+            sleep 1
+            timeout=$((timeout-1))
+          done
+          echo "Timeout waiting for health check"
+          exit 1
+      - name: Stop server
+        if: always()
+        run: |
+          kill $SERVER_PID || true


### PR DESCRIPTION
Resolves #107.

This PR overhauls the `main.yml` workflow to include multi-OS integration tests:
- **Linux**: Starts the container via `docker compose` and checks `/api/health`.
- **Windows**: Starts the container via `docker compose` and checks `/api/health` using PowerShell.
- **macOS**: Starts the Python server directly (native) and checks `/api/health` (since running Docker on macOS runners is extremely difficult).

These tests run after the Docker image is built and pushed to GHCR, ensuring that the released artifacts are actually working.