### PR TITLE
fix: Ensure git tags are fetched before uploading releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,12 @@ jobs:
         id: tag
         shell: bash
         run: |
+          git fetch --tags
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$TAG" ]; then
+            TAG=$(git rev-parse --short HEAD)
+            echo "Warning: No annotated tag found, using commit SHA: $TAG"
+          fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Upload Binaries to Release
         uses: softprops/action-gh-release@v2
@@ -160,7 +165,12 @@ jobs:
         id: tag
         shell: bash
         run: |
+          git fetch --tags
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$TAG" ]; then
+            TAG=$(git rev-parse --short HEAD)
+            echo "Warning: No annotated tag found, using commit SHA: $TAG"
+          fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Build and push Docker image
         id: docker_build
@@ -195,7 +205,12 @@ jobs:
         id: tag
         shell: bash
         run: |
+          git fetch --tags
           TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -z "$TAG" ]; then
+            TAG=$(git rev-parse --short HEAD)
+            echo "Warning: No annotated tag found, using commit SHA: $TAG"
+          fi
           echo "tag=$TAG" >> $GITHUB_OUTPUT
       - name: Upload Zip to Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Resolves #117.

This PR fixes the issue where the `build_assets` job (and others) fails with "GitHub Releases requires a tag".
Changes:
1. Added `git fetch --tags` before `git describe` to ensure the runner knows about the newly created tag.
2. Added fallback logic: if no tag is found, it uses the short commit SHA as a fallback tag name.

This applied to 3 jobs: `build_assets`, `build_docker`, and `build_zip_assets`.