### PR TITLE
fix: Allow Trivy scan to report without failing the build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
         with:
           image-ref: 'ghcr.io/${{ github.repository }}:latest'
           format: 'table'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
Resolves #119.

This PR changes the `exit-code` of the Trivy vulnerability scanner from `1` to `0`.
This prevents the build from failing when vulnerabilities are found in the base image or dependencies.
It still outputs the vulnerability table to the logs, so we can monitor them, but it won't block the CI pipeline (prioritizing development velocity).