### PR TITLE
fix: consolidated pipeline fixes and model change to gemma4:e2b

### DIFF
--- a/src/ripen/common/config.py
+++ b/src/ripen/common/config.py
@@ -22,10 +22,11 @@ GOOGLE_EMBEDDING_MODEL = "models/gemini-embedding-001"
 
 # Ollama Settings (Local host)
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
-OLLAMA_DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "llama3.1")
+OLLAMA_DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:31b")
 
 # FastEmbed Settings (Local vectorization)
 FASTEMBED_DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+
 
 
 class Settings:

--- a/src/ripen/common/config.py
+++ b/src/ripen/common/config.py
@@ -22,10 +22,11 @@ GOOGLE_EMBEDDING_MODEL = "models/gemini-embedding-001"
 
 # Ollama Settings (Local host)
 OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
-OLLAMA_DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:31b")
+OLLAMA_DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e2b")
 
 # FastEmbed Settings (Local vectorization)
 FASTEMBED_DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+
 
 
 


### PR DESCRIPTION
This PR consolidates fixes for the CI pipeline:
1. Windows native test instead of Docker.
2. Accept header for MCP initialize requests.
3. Default Ollama model set to `gemma4:e2b`.