### PR TITLE
fix: fix TypeError in salvage_related_knowledge call

### DIFF
--- a/src/ripen/core/thought_logic.py
+++ b/src/ripen/core/thought_logic.py
@@ -205,7 +205,7 @@ async def process_thought_core(
                 try:
                     # Give salvage 15 seconds max, it's not critical if it fails
                     related_knowledge = await asyncio.wait_for(
-                        salvage_related_knowledge(thought, session_id, history),
+                        salvage_related_knowledge(thought, session_id),
                         timeout=15.0
                     )
                 except TimeoutError:

--- a/src/ripen/infra/llm.py
+++ b/src/ripen/infra/llm.py
@@ -172,12 +172,12 @@ class GeminiProvider(LlmProvider):
             # Add explicit timeout to prevent indefinite hangs on network/API issues
             response = await asyncio.wait_for(
                 client.aio.models.generate_content(model=model, contents=full_prompt),
-                timeout=30.0
+                timeout=120.0
             )
             logger.info(f"Gemini response received. Model: {model}")
             return response.text
         except TimeoutError as e:
-            logger.error(f"Gemini API call TIMEOUT (30s) - Model: {model}")
+            logger.error(f"Gemini API call TIMEOUT (120s) - Model: {model}")
             raise Exception("AI Brain response timed out. Please try again.") from e
         except Exception as e:
             logger.error(f"Gemini API call failed: {e}")


### PR DESCRIPTION
`salvage_related_knowledge() takes 2 positional arguments but 3 were given` のエラーを修正しました。
また、ユーザーの指示に基づき、Gemini APIのタイムアウト時間を30秒から120秒に延長しました。

Closes #131