### PR TITLE
feat: fix docker compose project name to ripen

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: ripen
+
 services:
   ripen:
     image: ghcr.io/ayato-labs/ripen:latest


### PR DESCRIPTION
ディレクトリ名に依存せず、常に `ripen` というプロジェクト名で Docker リソースが作成されるように、`docker-compose.yml` に `name: ripen` を追加しました。

Closes #138