### PR TITLE
fix: Salvage failure due to argument mismatch (#146)

### DIFF
--- a/src/ripen/cli/salvage.py
+++ b/src/ripen/cli/salvage.py
@@ -18,9 +18,12 @@ async def salvage_related_knowledge(
         # Fetch Top Candidates (already ranked by Hybrid Search logic in core.search)
         # We EXPLICITLY exclude TRANSIENT logs from automated salvage to prevent
         # noise/hallucination loops.
-        graph_data, bank_data = await perform_search(
-            thought, candidate_limit=7, include_transient=False
-        )
+        from ripen.infra.uow import UnitOfWork
+
+        async with UnitOfWork() as uow:
+            graph_data, bank_data = await perform_search(
+                query=thought, uow=uow, limit=7, include_transient=False
+            )
 
         results = []
         # 1. Flatten troubleshooting (Highest Priority)


### PR DESCRIPTION
Closes #146. Fix TypeError in salvage.py where perform_search is called with candidate_limit instead of limit, and missing uow.