### PR TITLE
fix: trigger CI/CD pipeline on develop branch push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths-ignore:
       - 'docs/**'
       - 'README.md'


### PR DESCRIPTION
Closes #172. Adds develop to the push branches trigger in main.yml to ensure dev-latest pre-release builds are published automatically.