### PR TITLE
Refactor: remove legacy auth and unify transport naming for MVP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.19.1 (2026-05-24)
+
+### Bug Fixes
+
+- Ensure terminal does not close abruptly on fatal error
+  ([`fb63ccd`](https://github.com/ayato-labs/ripen/commit/fb63ccd1cf4a37e6f1634708e77561ba78116c30))
+
+
 ## v1.19.0 (2026-05-24)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 <!-- version list -->
 
+## v1.19.0 (2026-05-24)
+
+### Bug Fixes
+
+- Remove unnecessary macOS native test job
+  ([`bf7a858`](https://github.com/ayato-labs/ripen/commit/bf7a8587c9413a198b2f625f1a3ed0f223a97751))
+
+### Features
+
+- Add RipenInit binary release and document setup wizard
+  ([`16f8969`](https://github.com/ayato-labs/ripen/commit/16f896926578d1f549e2c766a645d6fc17a4bad3))
+
+
 ## v1.18.1 (2026-05-24)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 <!-- version list -->
 
+## v1.20.0 (2026-06-07)
+
+### Bug Fixes
+
+- Trigger CI/CD pipeline on develop branch push
+  ([`4267d5b`](https://github.com/ayato-labs/ripen/commit/4267d5b1356c952ee0647d17d8bcde404194cfdc))
+
+### Documentation
+
+- Add ADRs for enabling binary builds on PRs and publishing development pre-releases
+  ([`637b862`](https://github.com/ayato-labs/ripen/commit/637b8622ca07c8dcc86044807b23f73c04023321))
+
+### Features
+
+- Add CI/CD pipeline with linting, testing, semantic release, and Windows binary packaging workflows
+  ([`26e995e`](https://github.com/ayato-labs/ripen/commit/26e995e5cee9a7fbbf6548ce259a6b4b9d5565b1))
+
+- Add CLI initialization module to configure storage, LLM providers, and embedding engines
+  ([`e4eb469`](https://github.com/ayato-labs/ripen/commit/e4eb4698dd8777c8061a76f8fda2a28752a565ef))
+
+- Add interactive CLI setup utility for initial configuration
+  ([`6533729`](https://github.com/ayato-labs/ripen/commit/65337292df6fd06050df0f3d640335b8cf209999))
+
+- Add scratch scripts for conflict resolution and ADR persistence
+  ([`fa98785`](https://github.com/ayato-labs/ripen/commit/fa9878535a26a784ef723c2e5e4bfdf2e0abe040))
+
+- Customize setup wizard with LLM/embedding choices and add automatic re-embedding migration
+  ([`9e93ba4`](https://github.com/ayato-labs/ripen/commit/9e93ba4cab679fbe39f5fd0f217066afb0f29baf))
+
+- Implement interactive CLI initialization for Ripen configuration and LLM/embedding provider setup
+  ([`e758c42`](https://github.com/ayato-labs/ripen/commit/e758c429b9fe8429876312f3c3fba1d5cbb15e54))
+
+- Implement interactive CLI initialization script for configuration setup
+  ([`74e367d`](https://github.com/ayato-labs/ripen/commit/74e367db707d677ae05ccaae0e592192d1f9394a))
+
+- Implement Ripen Hub MCP server with memory tools and permissive handshake protocol patching
+  ([`7816733`](https://github.com/ayato-labs/ripen/commit/7816733d9c3342fe361047b70f53f5afffba0132))
+
+- Output private IP endpoints in setup wizard and server banner
+  ([`6f85149`](https://github.com/ayato-labs/ripen/commit/6f85149e30addc7adf8d04d11ebfc1d9ca7ae358))
+
+### Refactoring
+
+- Deprecate RipenInstaller and enable binary builds on develop
+  ([`a3e786a`](https://github.com/ayato-labs/ripen/commit/a3e786a2480b3721b38a9914df77a656617bec8b))
+
+- Publish dev builds as dev-latest pre-releases
+  ([`fc1e2ce`](https://github.com/ayato-labs/ripen/commit/fc1e2cec200a03a74b737680f36e5660f889eaaf))
+
+- Resolve ruff complexity and line length violations in setup wizard and migration ops
+  ([`48116ec`](https://github.com/ayato-labs/ripen/commit/48116ec477ea5ee4398dfe28957d69a32b2781df))
+
+
 ## v1.19.1 (2026-05-24)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## v1.21.0 (2026-06-07)
+
+### Features
+
+- Implement interactive CLI initialization for Ripen configuration
+  ([`988d839`](https://github.com/ayato-labs/ripen/commit/988d8391d0f552f209c165af6d576da643be5b80))
+
+
 ## v1.20.0 (2026-06-07)
 
 ### Bug Fixes

--- a/bin/start_hub.bat
+++ b/bin/start_hub.bat
@@ -3,7 +3,7 @@ setlocal
 pushd "%~dp0.."
 
 echo.
-echo [Ripen Hub] Starting Server (SSE Mode)...
+echo [Ripen Hub] Starting Server (Streamable HTTP Mode)...
 echo ----------------------------------------
 
 set PORT=8377

--- a/docs/ADR/ADR-0006-remove-auth-unify-transport.md
+++ b/docs/ADR/ADR-0006-remove-auth-unify-transport.md
@@ -1,0 +1,28 @@
+# ADR-0006: Removal of Authentication Logic and Transport Naming Unification for MVP
+
+- **Date**: 2026-06-13
+- **Status**: Proposed
+- **Deciders**: Gemini CLI (Agent), ayato-labs (User)
+
+## Context
+The Ripen MVP currently contains a legacy authentication logic (inherited from the "Shared Memory" project phase) that relies on environment variables like `RIPEN_API_KEY` and local files like `auth.json`. This logic is causing "Authentication required" errors for users who have not explicitly configured these keys, creating friction in the core value proposition of the product (knowledge persistence and retrieval).
+
+Additionally, the codebase uses inconsistent terminology for the transport layer, frequently referring to "SSE" (Server-Sent Events) while the underlying implementation has moved to "Streamable HTTP" as per FastMCP v3.0 standards.
+
+## Decision
+1.  **Remove Authentication Logic for MVP**: We will disable the `AuthMiddleware` and remove dependencies on `RIPEN_API_KEY`, `SHARED_MEMORY_API_KEY`, and `auth.json`. All requests will default to a single user (`default_env_user` or the OS username) without requiring a token.
+2.  **Unify Transport Terminology**: Rename internal variables, configuration keys, and log messages from "SSE" to "Streamable HTTP" (or simply "HTTP") to align with current architectural standards.
+3.  **Defer Advanced Auth**: Robust authentication (JWT, multi-user isolation) will be reconsidered as a post-MVP feature once the core memory functions are stabilized and verified in team environments.
+
+## Consequences
+### Positive
+- **Reduced Friction**: Users can start the Hub and connect agents without troubleshooting authentication errors.
+- **Architectural Clarity**: Removal of legacy/unused code paths simplifies debugging and future development.
+- **Improved Documentation**: Aligning code terminology with FastMCP standards makes the system easier to understand for new contributors.
+
+### Negative / Risks
+- **No Access Control**: In the MVP phase, any agent on the same network (if host is `0.0.0.0`) can read/write to the hub. This is accepted for the current development stage and LAN-only use cases.
+
+## References
+- Issue: #180
+- Related: [FastMCP Streamable HTTP Documentation]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ripen"
-version = "1.20.0"
+version = "1.21.0"
 description = "The centralized knowledge hub for AI agents. Hybrid Vector + Graph memory with autonomous distillation."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ripen"
-version = "1.19.0"
+version = "1.19.1"
 description = "The centralized knowledge hub for AI agents. Hybrid Vector + Graph memory with autonomous distillation."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ripen"
-version = "1.18.1"
+version = "1.19.0"
 description = "The centralized knowledge hub for AI agents. Hybrid Vector + Graph memory with autonomous distillation."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ripen"
-version = "1.19.1"
+version = "1.20.0"
 description = "The centralized knowledge hub for AI agents. Hybrid Vector + Graph memory with autonomous distillation."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/ripen/api/admin_server.py
+++ b/src/ripen/api/admin_server.py
@@ -7,23 +7,16 @@ from ripen.infra.uow import SecureWriteContext, UnitOfWork
 # Create MCP server instance (Control Plane / Admin)
 mcp = FastMCP("SharedMemoryAdminServer")
 
-from ripen.api.auth import AuthMiddleware, get_current_user
+from ripen.api.auth import get_current_user
 from ripen.common.utils import get_logger
 
 logger = get_logger("admin_server")
 
-if hasattr(mcp, "app"):
-    logger.info("Applying AuthMiddleware to mcp.app")
-    mcp.app.add_middleware(AuthMiddleware)
-else:
-    logger.warning("mcp instance does not have 'app' attribute. Could not apply AuthMiddleware.")
-
 def enforce_auth():
-    user = get_current_user()
-    if not user:
-        raise Exception("Authentication required. Please provide a valid API key.")
-    return user
-
+    """
+    Legacy helper. In MVP, authentication is handled by a default user.
+    """
+    return get_current_user()
 
 
 # ==========================================

--- a/src/ripen/api/auth.py
+++ b/src/ripen/api/auth.py
@@ -1,6 +1,6 @@
+import getpass
 import os
 from contextvars import ContextVar
-import getpass
 
 from ripen.common.utils import get_logger
 

--- a/src/ripen/api/auth.py
+++ b/src/ripen/api/auth.py
@@ -1,7 +1,6 @@
-import json
 import os
-from abc import ABC, abstractmethod
 from contextvars import ContextVar
+import getpass
 
 from ripen.common.utils import get_logger
 
@@ -12,128 +11,16 @@ current_user: ContextVar[str | None] = ContextVar("current_user", default=None)
 in_http_request: ContextVar[bool] = ContextVar("in_http_request", default=False)
 
 
-
-class IAuthProvider(ABC):
-    """Interface for authentication providers."""
-
-    @abstractmethod
-    async def authenticate(self, api_key: str) -> str | None:
-        """
-        Authenticates a request using an API key.
-        Returns the account name if successful, else None.
-        """
-        pass
-
-
-class LocalFileAuthProvider(IAuthProvider):
-    """Auth provider that uses a local JSON file (auth.json)."""
-
-    def __init__(self, auth_file_path: str = "data/auth.json"):
-        self.auth_file_path = auth_file_path
-        self.auth_data = {}
-        self._load_auth_data()
-
-    def _load_auth_data(self):
-        if not os.path.exists(self.auth_file_path):
-            logger.warning(f"Auth file not found at {self.auth_file_path}")
-            return
-        try:
-            with open(self.auth_file_path, encoding="utf-8") as f:
-                self.auth_data = json.load(f)
-            logger.info(f"Loaded {len(self.auth_data)} accounts from {self.auth_file_path}")
-        except Exception as e:
-            logger.error(f"Failed to load auth file: {e}")
-
-    async def authenticate(self, api_key: str) -> str | None:
-        for acc, key in self.auth_data.items():
-            if key == api_key:
-                return acc
-        return None
-
-
-class EnvAuthProvider(IAuthProvider):
-    """Auth provider that uses environment variables."""
-
-    async def authenticate(self, api_key: str) -> str | None:
-        env_key = os.environ.get("RIPEN_API_KEY") or os.environ.get("SHARED_MEMORY_API_KEY")
-        env_acc = os.environ.get("RIPEN_ACCOUNT") or os.environ.get(
-            "SHARED_MEMORY_ACCOUNT", "default_env_user"
-        )
-        if env_key and api_key == env_key:
-            return env_acc
-        return None
-
-
-class AuthMiddleware:
-    """ASGI middleware for authentication using pluggable providers."""
-
-    def __init__(self, app, providers: list[IAuthProvider] | None = None):
-        self.app = app
-        self.providers = providers or [LocalFileAuthProvider(), EnvAuthProvider()]
-
-    async def __call__(self, scope, receive, send):
-        if scope["type"] != "http":
-            return await self.app(scope, receive, send)
-
-        # 1. Extract API Key
-        api_key = None
-        headers = dict(scope.get("headers", []))
-
-        x_api_key = headers.get(b"x-api-key")
-        if x_api_key:
-            api_key = x_api_key.decode()
-        else:
-            auth_header = headers.get(b"authorization", b"").decode()
-            if auth_header.startswith("Bearer "):
-                api_key = auth_header[7:]
-
-        # 2. Try each provider
-        account_name = None
-        if api_key:
-            for provider in self.providers:
-                account_name = await provider.authenticate(api_key)
-                if account_name:
-                    break
-
-        # Fallback if authentication is not configured at all
-        if not account_name:
-            env_key = os.environ.get("RIPEN_API_KEY") or os.environ.get("SHARED_MEMORY_API_KEY")
-            has_file_keys = False
-            for provider in self.providers:
-                if isinstance(provider, LocalFileAuthProvider):
-                    if provider.auth_data:
-                        has_file_keys = True
-            if not (env_key or has_file_keys):
-                account_name = os.environ.get("RIPEN_ACCOUNT") or os.environ.get(
-                    "SHARED_MEMORY_ACCOUNT", "default_env_user"
-                )
-
-        if account_name:
-            logger.debug(f"Authenticated request from: {account_name}")
-        else:
-            logger.debug(f"Unauthenticated request to {scope.get('path', '')}")
-
-        # 3. Set context and continue
-        token_http = in_http_request.set(True)
-        token = current_user.set(account_name)
-        try:
-            return await self.app(scope, receive, send)
-        finally:
-            current_user.reset(token)
-            in_http_request.reset(token_http)
-
-
-def get_current_user() -> str | None:
-    """Returns the authenticated account name for the current context."""
+def get_current_user() -> str:
+    """
+    Returns the account name for the current context.
+    In MVP phase, this always returns a default user (RIPEN_ACCOUNT or OS username).
+    """
     user = current_user.get()
-    if user is not None:
+    if user:
         return user
 
-    # If we are NOT in an HTTP request (e.g., stdio transport, direct CLI tool calls, or tests),
-    # return the default/configured local user.
-    if not in_http_request.get():
-        return os.environ.get("RIPEN_ACCOUNT") or os.environ.get(
-            "SHARED_MEMORY_ACCOUNT", "default_env_user"
-        )
-
-    return None
+    # Default fallback for MVP
+    return os.environ.get("RIPEN_ACCOUNT") or os.environ.get(
+        "SHARED_MEMORY_ACCOUNT", getpass.getuser()
+    )

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -49,15 +49,7 @@ mcp = FastMCP(
     version="3.2.4",
 )
 
-from ripen.api.auth import AuthMiddleware, get_current_user
-
-if hasattr(mcp, "app"):
-    logger.info("Applying AuthMiddleware to mcp.app")
-    mcp.app.add_middleware(AuthMiddleware)
-else:
-    logger.warning("mcp instance does not have 'app' attribute. Could not apply AuthMiddleware.")
-
-
+from ripen.api.auth import get_current_user
 
 
 def handle_exception(_loop, context):
@@ -151,8 +143,6 @@ async def save_memory(
         f"Tool called: save_memory (Entities: {len(entities)}, Relations: {len(relations)})"
     )
     user = agent_id or get_current_user()
-    if not user:
-        raise Exception("Authentication required. Please provide a valid API key.")
     try:
         await logic_module.save_memory_core(
             entities=entities,
@@ -196,8 +186,6 @@ async def sequential_thinking(
     """
     logger.info(f"Tool called: sequential_thinking (Thought {thought_number}/{total_thoughts})")
     user = get_current_user()
-    if not user:
-        raise Exception("Authentication required. Please provide a valid API key.")
     try:
         result = await thought_module.process_thought_core(
             thought=thought,
@@ -394,6 +382,9 @@ def main():
     parser = argparse.ArgumentParser(description="Ripen Hub Server")
     parser.add_argument("--port", type=int, help="Port for the server")
     parser.add_argument("--host", default="0.0.0.0", help="Host for the server")
+    parser.add_argument("--http", action="store_true", help="Start in Streamable HTTP mode")
+    parser.add_argument("--sse", action="store_true", help="Alias for --http (Deprecated)")
+    parser.add_argument("--stdio", action="store_true", help="Start in Standard I/O mode")
     parser.add_argument("--dev", action="store_true", help="Start in development mode")
 
 
@@ -402,6 +393,19 @@ def main():
 
     if args.dev:
         os.environ["LOG_LEVEL"] = "DEBUG"
+    
+    # Mode Detection
+    use_http = args.http or args.sse
+    use_stdio = args.stdio
+    
+    if not use_http and not use_stdio:
+        # Default to config
+        use_http = settings.default_transport == "streamable-http"
+        use_stdio = settings.default_transport == "stdio"
+    
+    # If still neither, default to HTTP for Hub
+    if not use_http and not use_stdio:
+        use_http = True
 
     # Handle termination signals
     def handle_signal(sig, _frame):
@@ -411,47 +415,55 @@ def main():
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
-    port = args.port or settings.sse_port or 8377
-    logger.info(f"Port check: port={port}")
+    if use_http:
+        # Use http_port from settings as default
+        port = args.port or settings.http_port or 8377
+        logger.info(f"Port check: port={port}")
 
-    logger.info("Starting cleanup and port check...")
-    _kill_port_process(port)
-    logger.info("Cleanup completed. Checking port availability...")
+        logger.info("Starting cleanup and port check...")
+        _kill_port_process(port)
+        logger.info("Cleanup completed. Checking port availability...")
 
-    # Double check port availability
-    import socket
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    result = sock.connect_ex(("127.0.0.1", port))
-    if result == 0:
-        logger.error(
-            f"PORT CONFLICT: Port {port} is already in use by another process. "
-            f"Please stop all other Ripen Hub instances."
-        )
+        # Double check port availability
+        import socket
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        result = sock.connect_ex(("127.0.0.1", port))
+        if result == 0:
+            logger.error(
+                f"PORT CONFLICT: Port {port} is already in use by another process. "
+                f"Please stop all other Ripen Hub instances."
+            )
+            sock.close()
+            sys.exit(1)
         sock.close()
-        sys.exit(1)
-    sock.close()
-    logger.info("Port is available.")
+        logger.info("Port is available.")
 
-    # Load plugins before starting
-    logger.info("Loading plugins...")
-    PluginLoader.load_all(context={"settings": settings})
-    logger.info("Plugins loaded. Printing banner...")
-    print_banner("Streamable HTTP", port, version)
-    logger.info("Banner printed. Running FastMCP server...")
+        # Load plugins before starting
+        logger.info("Loading plugins...")
+        PluginLoader.load_all(context={"settings": settings})
+        logger.info("Plugins loaded. Printing banner...")
+        print_banner("Streamable HTTP", port, version)
+        logger.info("Banner printed. Running FastMCP server...")
 
-    local_ip = get_local_ip()
-    hostname = get_local_hostname()
-    logger.info(f"Ripen Server starting on host: {args.host}, port: {port}")
-    logger.info(f"API Endpoint (local): http://localhost:{port}/mcp")
-    if args.host == "0.0.0.0":
-        if local_ip != "127.0.0.1":
-            logger.info(f"API Endpoint (network IP): http://{local_ip}:{port}/mcp")
-            logger.info(f"Dashboard (network IP): http://{local_ip}:{port}/dashboard")
-        if hostname:
-            logger.info(f"API Endpoint (mDNS hostname): http://{hostname}.local:{port}/mcp")
-            logger.info(f"Dashboard (mDNS hostname): http://{hostname}.local:{port}/dashboard")
+        local_ip = get_local_ip()
+        hostname = get_local_hostname()
+        logger.info(f"Ripen Server starting on host: {args.host}, port: {port}")
+        logger.info(f"API Endpoint (local): http://localhost:{port}/mcp")
+        if args.host == "0.0.0.0":
+            if local_ip != "127.0.0.1":
+                logger.info(f"API Endpoint (network IP): http://{local_ip}:{port}/mcp")
+                logger.info(f"Dashboard (network IP): http://{local_ip}:{port}/dashboard")
+            if hostname:
+                logger.info(f"API Endpoint (mDNS hostname): http://{hostname}.local:{port}/mcp")
+                logger.info(f"Dashboard (mDNS hostname): http://{hostname}.local:{port}/dashboard")
 
-    mcp.run(transport="streamable-http", host=args.host, port=port, show_banner=False)
+        mcp.run(transport="streamable-http", host=args.host, port=port, show_banner=False)
+    else:
+        # Stdio mode
+        logger.info("Starting Ripen Hub in Standard I/O mode...")
+        # Load plugins
+        PluginLoader.load_all(context={"settings": settings})
+        mcp.run(transport="stdio")
 
 
 def _kill_port_process(port: int):

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -368,6 +368,50 @@ def print_banner(mode: str, port: int, version: str):
             sys.stderr.write(line.encode('ascii', 'ignore').decode('ascii') + "\n")
     sys.stderr.flush()
 
+
+def _verify_port_is_free(port: int):
+    """Checks if a port is available and exits if not."""
+    import socket
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = sock.connect_ex(("127.0.0.1", port))
+    if result == 0:
+        logger.error(
+            f"PORT CONFLICT: Port {port} is already in use by another process. "
+            f"Please stop all other Ripen Hub instances."
+        )
+        sock.close()
+        sys.exit(1)
+    sock.close()
+    logger.info("Port is available.")
+
+
+def _detect_mode(args: argparse.Namespace) -> tuple[bool, bool]:
+    """Determines transport mode based on args and settings."""
+    use_http = args.http or args.sse
+    use_stdio = args.stdio
+    
+    if not use_http and not use_stdio:
+        use_http = settings.default_transport == "streamable-http"
+        use_stdio = settings.default_transport == "stdio"
+    
+    if not use_http and not use_stdio:
+        use_http = True
+        
+    return use_http, use_stdio
+
+
+def _log_endpoints(host: str, port: int, local_ip: str, hostname: str):
+    """Logs the accessibility endpoints."""
+    logger.info(f"API Endpoint (local): http://localhost:{port}/mcp")
+    if host == "0.0.0.0":
+        if local_ip != "127.0.0.1":
+            logger.info(f"API Endpoint (network IP): http://{local_ip}:{port}/mcp")
+            logger.info(f"Dashboard (network IP): http://{local_ip}:{port}/dashboard")
+        if hostname:
+            logger.info(f"API Endpoint (mDNS hostname): http://{hostname}.local:{port}/mcp")
+            logger.info(f"Dashboard (mDNS hostname): http://{hostname}.local:{port}/dashboard")
+
+
 def main():
     configure_logging()
     import importlib.metadata
@@ -376,8 +420,6 @@ def main():
     except importlib.metadata.PackageNotFoundError:
         version = "unknown"
     logger.info(f"--- SERVER SCRIPT STARTING (Version: {version}) ---")
-    logger.info(f"Main execution started (Args: {sys.argv})")
-
 
     parser = argparse.ArgumentParser(description="Ripen Hub Server")
     parser.add_argument("--port", type=int, help="Port for the server")
@@ -387,81 +429,27 @@ def main():
     parser.add_argument("--stdio", action="store_true", help="Start in Standard I/O mode")
     parser.add_argument("--dev", action="store_true", help="Start in development mode")
 
-
     args = parser.parse_args()
-    logger.debug("Arguments parsed successfully.")
-
     if args.dev:
         os.environ["LOG_LEVEL"] = "DEBUG"
     
-    # Mode Detection
-    use_http = args.http or args.sse
-    use_stdio = args.stdio
-    
-    if not use_http and not use_stdio:
-        # Default to config
-        use_http = settings.default_transport == "streamable-http"
-        use_stdio = settings.default_transport == "stdio"
-    
-    # If still neither, default to HTTP for Hub
-    if not use_http and not use_stdio:
-        use_http = True
+    use_http, _ = _detect_mode(args)
 
-    # Handle termination signals
-    def handle_signal(sig, _frame):
-        logger.info(f"Signal {sig} received. Shutting down...")
-        sys.exit(0)
-
-    signal.signal(signal.SIGINT, handle_signal)
-    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, lambda _s, _f: sys.exit(0))
+    signal.signal(signal.SIGTERM, lambda _s, _f: sys.exit(0))
 
     if use_http:
-        # Use http_port from settings as default
         port = args.port or settings.http_port or 8377
-        logger.info(f"Port check: port={port}")
-
-        logger.info("Starting cleanup and port check...")
         _kill_port_process(port)
-        logger.info("Cleanup completed. Checking port availability...")
+        _verify_port_is_free(port)
 
-        # Double check port availability
-        import socket
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        result = sock.connect_ex(("127.0.0.1", port))
-        if result == 0:
-            logger.error(
-                f"PORT CONFLICT: Port {port} is already in use by another process. "
-                f"Please stop all other Ripen Hub instances."
-            )
-            sock.close()
-            sys.exit(1)
-        sock.close()
-        logger.info("Port is available.")
-
-        # Load plugins before starting
-        logger.info("Loading plugins...")
         PluginLoader.load_all(context={"settings": settings})
-        logger.info("Plugins loaded. Printing banner...")
         print_banner("Streamable HTTP", port, version)
-        logger.info("Banner printed. Running FastMCP server...")
-
-        local_ip = get_local_ip()
-        hostname = get_local_hostname()
-        logger.info(f"Ripen Server starting on host: {args.host}, port: {port}")
-        logger.info(f"API Endpoint (local): http://localhost:{port}/mcp")
-        if args.host == "0.0.0.0":
-            if local_ip != "127.0.0.1":
-                logger.info(f"API Endpoint (network IP): http://{local_ip}:{port}/mcp")
-                logger.info(f"Dashboard (network IP): http://{local_ip}:{port}/dashboard")
-            if hostname:
-                logger.info(f"API Endpoint (mDNS hostname): http://{hostname}.local:{port}/mcp")
-                logger.info(f"Dashboard (mDNS hostname): http://{hostname}.local:{port}/dashboard")
-
+        
+        _log_endpoints(args.host, port, get_local_ip(), get_local_hostname())
         mcp.run(transport="streamable-http", host=args.host, port=port, show_banner=False)
     else:
-        # Stdio mode
         logger.info("Starting Ripen Hub in Standard I/O mode...")
-        # Load plugins
         PluginLoader.load_all(context={"settings": settings})
         mcp.run(transport="stdio")
 
@@ -475,61 +463,37 @@ def _kill_port_process(port: int):
         return
 
     current_pid = os.getpid()
-    logger.info(f"Executing _kill_port_process for port {port} (Current PID: {current_pid})")
     try:
         import subprocess
         # 1. Kill by port
         cmd = f"netstat -ano | findstr :{port}"
-        logger.debug(f"Running: {cmd}")
         try:
             output = subprocess.check_output(cmd, shell=True).decode()
-            logger.debug(f"netstat output: {output}")
             for line in output.strip().split("\n"):
                 if "LISTENING" in line:
-                    parts = line.strip().split()
-                    if parts:
-                        pid = parts[-1]
-                        try:
-                            pid_int = int(pid)
-                            if pid_int not in (0, current_pid):
-                                logger.warning(f"Killing zombie process {pid_int} on port {port}")
-                                subprocess.run(
-                                    ["taskkill", "/F", "/T", "/PID", str(pid_int)],
-                                    check=False,
-                                    capture_output=True,
-                                )
-                        except ValueError:
-                            logger.warning(f"Could not parse PID from line: {line}")
+                    pid = line.strip().split()[-1]
+                    if int(pid) not in (0, current_pid):
+                        subprocess.run(
+                            ["taskkill", "/F", "/T", "/PID", pid],
+                            check=False,
+                            capture_output=True
+                        )
         except subprocess.CalledProcessError:
-            logger.debug("No process found listening on port.")
+            pass
 
-        # 2. Kill by name (Aggressive Cleanup)
-        # This ensures no duplicate proxies or hubs are hanging around
-        # We MUST exclude our own PID to avoid self-termination
-        logger.debug("Performing aggressive cleanup...")
-        # Note: taskkill /IM kills by process name. If the current process is
-        # ripen.exe, this would kill it.
-        # We use /FI to exclude the current PID.
+        # 2. Kill by name
         subprocess.run(
             f'taskkill /F /IM ripen.exe /FI "PID ne {current_pid}"',
-            shell=True,
-            check=False,
-            capture_output=True,
+            shell=True, check=False, capture_output=True
         )
-        
-        # We removed the WMIC-based cleanup because its command line often matched 
-        # the filter pattern, causing the shell to terminate prematurely.
-        # The netstat check above is sufficient for port conflicts.
-            
     except Exception as e:
         logger.error(f"Aggressive cleanup failed: {e}")
 
 
 async def wait_for_background_tasks(timeout: float = 5.0):
-    """
-    Waits for all registered background tasks to complete or timeout.
-    """
+    """Waits for all registered background tasks to complete or timeout."""
     await _wait_tasks(timeout=timeout)
+
 
 if __name__ == "__main__":
     safe_main_executor(main)()

--- a/src/ripen/cli/init.py
+++ b/src/ripen/cli/init.py
@@ -284,8 +284,10 @@ def main():
     configure_embeddings(config, existing_config)
 
     # 4. Port & Transport
-    config["sse_port"] = existing_config.get("sse_port") or 8377
-    config["default_transport"] = existing_config.get("default_transport") or "sse"
+    config["http_port"] = existing_config.get("http_port") or existing_config.get("sse_port") or 8377
+    config["default_transport"] = existing_config.get("default_transport") or "streamable-http"
+    if config["default_transport"] == "sse":
+        config["default_transport"] = "streamable-http"
 
     # 5. Save Config
     ripen_home_path = Path(config["ripen_home"])
@@ -314,7 +316,7 @@ def main():
                 return "127.0.0.1"
 
     local_ip = get_local_ip()
-    port = config.get("sse_port") or 8377
+    port = config.get("http_port") or 8377
     
     logger.info(f"\nClient Connection URL (Local):  \033[1;33mhttp://localhost:{port}/mcp\033[0m")
     if local_ip != "127.0.0.1":

--- a/src/ripen/cli/init.py
+++ b/src/ripen/cli/init.py
@@ -284,7 +284,8 @@ def main():
     configure_embeddings(config, existing_config)
 
     # 4. Port & Transport
-    config["http_port"] = existing_config.get("http_port") or existing_config.get("sse_port") or 8377
+    port = existing_config.get("http_port") or existing_config.get("sse_port") or 8377
+    config["http_port"] = port
     config["default_transport"] = existing_config.get("default_transport") or "streamable-http"
     if config["default_transport"] == "sse":
         config["default_transport"] = "streamable-http"

--- a/src/ripen/common/config.py
+++ b/src/ripen/common/config.py
@@ -28,8 +28,6 @@ OLLAMA_DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e2b")
 FASTEMBED_DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
 
 
-
-
 class Settings:
     """Ripenの設定を管理するクラス。"""
 
@@ -136,7 +134,6 @@ class Settings:
             return provider.lower()
         return DEFAULT_LLM_PROVIDER
 
-
     @property
     def ollama_base_url(self) -> str:
         """OllamaのベースURLを返す。"""
@@ -179,10 +176,11 @@ class Settings:
         """現在選択されているプロバイダーに応じた生成モデル名を返す。"""
         if self.llm_provider == "ollama":
             return self.ollama_model
-        
+
         # Avoid circular import by importing inside the property
         try:
             from ripen.core.ai_control import model_manager
+
             return model_manager.get_current_model("generation")
         except (ImportError, Exception):
             # Fallback to default if model_manager is not available
@@ -205,13 +203,26 @@ class Settings:
 
     @property
     def default_transport(self) -> str:
-        """デフォルトの通信方式 (stdio or sse) を返す。"""
-        return self.get("DEFAULT_TRANSPORT", "stdio").lower()
+        """デフォルトの通信方式 (stdio or streamable-http) を返す。"""
+        transport = self.get("DEFAULT_TRANSPORT", "stdio").lower()
+        if transport == "sse":
+            return "streamable-http"
+        return transport
+
+    @property
+    def http_port(self) -> int:
+        """HTTPモードで使用するポート番号を返す。"""
+        # Support both HTTP_PORT and SSE_PORT for backward compatibility
+        port = self.get("HTTP_PORT") or self.get("SSE_PORT")
+        if port:
+            return int(port)
+        return 8377
 
     @property
     def sse_port(self) -> int:
-        """SSEモードで使用するポート番号を返す。"""
-        return int(self.get("SSE_PORT", "8377"))
+        """SSEモードで使用するポート番号を返す (DEPRECATED)。"""
+        logger.warning("sse_port is deprecated. Use http_port instead.")
+        return self.http_port
 
     @property
     def db_path(self) -> Path:

--- a/src/ripen/ops/hub_manager.py
+++ b/src/ripen/ops/hub_manager.py
@@ -41,14 +41,14 @@ def ensure_hub_running(port: int = 8377) -> bool:
     logger.info(f"Ripen Hub not detected on port {port}. Attempting to start in background...")
     
     # On Windows, we use CREATE_NO_WINDOW and DETACHED_PROCESS to run in background
-    # We use 'uv run ripen --sse' as the command
+    # We use 'uv run ripen --http' as the command
     try:
         # Determine the command to run. 
-        # If we are running via uv, we should use 'uv run ripen --sse'
-        # To be safe, we use 'sys.executable -m ripen.api.server --sse' 
-        # but since 'ripen' is a registered script, 'ripen --sse' should work if in path.
+        # If we are running via uv, we should use 'uv run ripen --http'
+        # To be safe, we use 'sys.executable -m ripen.api.server --http' 
+        # but since 'ripen' is a registered script, 'ripen --http' should work if in path.
         
-        cmd = [sys.executable, "-m", "ripen.api.server", "--sse", "--port", str(port)]
+        cmd = [sys.executable, "-m", "ripen.api.server", "--http", "--port", str(port)]
         
         # Set up diagnostic logging for startup
         from ripen.common.config import settings


### PR DESCRIPTION
## Summary
This PR removes the legacy authentication logic and unifies the transport terminology to "Streamable HTTP" to align with FastMCP v3.0 standards and simplify the architecture for MVP.

## Changes
- **Auth Removal**:
  - Removed `AuthMiddleware` and legacy `IAuthProvider` implementations in `auth.py`.
  - Simplified `get_current_user` to always return a default user for MVP.
  - Removed explicit authentication checks in `server.py` and `admin_server.py`.
- **Transport Naming Unification**:
  - Renamed `sse_port` to `http_port` in `config.py` (with deprecated alias).
  - Updated `default_transport` to use `streamable-http`.
  - Added `--http` argument to `server.py` and made `--sse` a deprecated alias.
  - Updated log messages, banners, and setup wizard to use "Streamable HTTP".
- **Documentation**:
  - Added `ADR-0006: Removal of Authentication Logic and Transport Naming Unification for MVP`.

Closes #180
