### PR TITLE
test: fix flaky system test with dynamic health check (follow-up)

### DIFF
--- a/docs/ADR/ADR-0006-remove-auth-unify-transport.md
+++ b/docs/ADR/ADR-0006-remove-auth-unify-transport.md
@@ -13,12 +13,14 @@ Additionally, the codebase uses inconsistent terminology for the transport layer
 1.  **Remove Authentication Logic for MVP**: We will disable the `AuthMiddleware` and remove dependencies on `RIPEN_API_KEY`, `SHARED_MEMORY_API_KEY`, and `auth.json`. All requests will default to a single user (`default_env_user` or the OS username) without requiring a token.
 2.  **Unify Transport Terminology**: Rename internal variables, configuration keys, and log messages from "SSE" to "Streamable HTTP" (or simply "HTTP") to align with current architectural standards.
 3.  **Defer Advanced Auth**: Robust authentication (JWT, multi-user isolation) will be reconsidered as a post-MVP feature once the core memory functions are stabilized and verified in team environments.
+4.  **Adopt Dynamic Health Checks for System Tests**: Replace fixed `time.sleep()` calls in system test fixtures with dynamic health check loops. This ensures tests wait the minimum necessary time for the server to be ready while providing a longer overall timeout for slower CI/CD environments.
 
 ## Consequences
 ### Positive
 - **Reduced Friction**: Users can start the Hub and connect agents without troubleshooting authentication errors.
 - **Architectural Clarity**: Removal of legacy/unused code paths simplifies debugging and future development.
 - **Improved Documentation**: Aligning code terminology with FastMCP standards makes the system easier to understand for new contributors.
+- **Reliable CI/CD**: Dynamic health checks eliminate race conditions in system tests, reducing flaky build failures.
 
 ### Negative / Risks
 - **No Access Control**: In the MVP phase, any agent on the same network (if host is `0.0.0.0`) can read/write to the hub. This is accepted for the current development stage and LAN-only use cases.

--- a/tests/system/test_server_http.py
+++ b/tests/system/test_server_http.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -8,32 +9,46 @@ import httpx
 import pytest
 
 
-@pytest.fixture(scope="module")
-def server_process():
-    """Starts the Ripen Hub server in a background process."""
+def _prepare_test_env(test_dir: str) -> dict:
+    """Sets up the environment variables and directories for the test server."""
     env = os.environ.copy()
-    
-    # Ensure we use the correct path to src
     src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "src"))
     if "PYTHONPATH" in env:
         env["PYTHONPATH"] = src_path + os.pathsep + env["PYTHONPATH"]
     else:
         env["PYTHONPATH"] = src_path
 
-    # Use a specific directory in the project
-    test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "test_db"))
     os.makedirs(test_dir, exist_ok=True)
     os.makedirs(os.path.join(test_dir, "bank"), exist_ok=True)
-    
     env["MEMORY_DB_PATH"] = os.path.join(test_dir, "knowledge.db")
     env["THOUGHTS_DB_PATH"] = os.path.join(test_dir, "thoughts.db")
     env["MEMORY_BANK_DIR"] = os.path.join(test_dir, "bank")
+    return env
 
-    # Use a file for logs to avoid blocking on pipe buffer
+
+def _stop_server_process(process: subprocess.Popen):
+    """Gracefully stops the server process."""
+    if process.poll() is None:
+        if sys.platform == "win32":
+            process.terminate()
+        else:
+            process.send_signal(signal.SIGTERM)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+
+
+@pytest.fixture(scope="module")
+def server_process():
+    """Starts the Ripen Hub server in a background process."""
+    test_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "test_db"))
+    env = _prepare_test_env(test_dir)
+
     log_file_path = os.path.join(test_dir, "server.log")
     log_file = open(log_file_path, "w", encoding="utf-8")
 
-    # Start the server
     process = subprocess.Popen(
         [sys.executable, "-m", "ripen.api.server", "--port", "8377"],
         stdout=log_file,
@@ -41,65 +56,44 @@ def server_process():
         text=True,
         env=env
     )
-    
-    # Wait for the server to start and listen on port
+
     max_retries = 30
     retry_interval = 1
     server_ready = False
-    
-    for attempt in range(max_retries):
+
+    for _attempt in range(max_retries):
         if process.poll() is not None:
             log_file.close()
             with open(log_file_path, encoding="utf-8") as f:
                 logs = f.read()
-            pytest.fail(f"Server process died unexpectedly with code {process.returncode}. Logs:\n{logs}")
-            
+            msg = f"Server process died unexpectedly with code {process.returncode}. Logs:\n{logs}"
+            pytest.fail(msg)
+
         try:
-            # We use a simple HTTP GET to check if the server is responding
             response = httpx.get("http://localhost:8377/dashboard/", timeout=1.0)
             if response.status_code in [200, 307, 401, 404]:
                 server_ready = True
                 break
         except Exception:
             time.sleep(retry_interval)
-            
+
     if not server_ready:
         log_file.close()
         with open(log_file_path, encoding="utf-8") as f:
             logs = f.read()
-        pytest.fail(f"Server failed to start and respond after {max_retries} seconds. Logs:\n{logs}")
-    
+        msg = f"Server failed to start and respond after {max_retries} seconds. Logs:\n{logs}"
+        pytest.fail(msg)
+
     yield process
-    
-    # Teardown: Stop the server
-    if process.poll() is None:
-        if sys.platform == "win32":
-            process.terminate()
-        else:
-            process.send_signal(signal.SIGTERM)
-        
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            print("Server did not terminate gracefully, killing it...")
-            process.kill()
-            process.wait()
-            
+
+    _stop_server_process(process)
     log_file.close()
-    
-    # Read logs for debugging output in test
-    print("\n--- Server Logs ---")
+
     if os.path.exists(log_file_path):
         with open(log_file_path, encoding="utf-8") as f:
-            print(f.read())
-    print("-------------------")
-    
-    # Clean up test database
-    try:
-        import shutil
-        shutil.rmtree(test_dir, ignore_errors=True)
-    except Exception as e:
-        print(f"DEBUG: Failed to clean up test_dir: {e}")
+            print(f"\n--- Server Logs ---\n{f.read()}\n-------------------")
+
+    shutil.rmtree(test_dir, ignore_errors=True)
 
 
 @pytest.mark.asyncio
@@ -108,20 +102,15 @@ async def test_server_http_connectivity(server_process):
     """
     System Test: サーバーが起動し、HTTPリクエストを受け付けることを検証。
     """
-    # サーバーが生きていることを確認
     assert server_process.poll() is None, "Server process died before test started"
 
-    # HTTPリクエストの送信
     async with httpx.AsyncClient() as client:
-        # 1. /dashboard にリクエスト
         try:
             response = await client.get("http://localhost:8377/dashboard/", timeout=5.0)
             assert response.status_code in [200, 307, 401, 404]
-            print(f"DEBUG: Dashboard response status: {response.status_code}")
         except httpx.ConnectError:
             pytest.fail("Failed to connect to the server on port 8377 for dashboard")
 
-        # 2. MCP プロトコル（JSON-RPC）のエンドポイントを叩く
         try:
             response = await client.post(
                 "http://localhost:8377/mcp",

--- a/tests/system/test_server_http.py
+++ b/tests/system/test_server_http.py
@@ -43,7 +43,31 @@ def server_process():
     )
     
     # Wait for the server to start and listen on port
-    time.sleep(10)
+    max_retries = 30
+    retry_interval = 1
+    server_ready = False
+    
+    for attempt in range(max_retries):
+        if process.poll() is not None:
+            log_file.close()
+            with open(log_file_path, encoding="utf-8") as f:
+                logs = f.read()
+            pytest.fail(f"Server process died unexpectedly with code {process.returncode}. Logs:\n{logs}")
+            
+        try:
+            # We use a simple HTTP GET to check if the server is responding
+            response = httpx.get("http://localhost:8377/dashboard/", timeout=1.0)
+            if response.status_code in [200, 307, 401, 404]:
+                server_ready = True
+                break
+        except Exception:
+            time.sleep(retry_interval)
+            
+    if not server_ready:
+        log_file.close()
+        with open(log_file_path, encoding="utf-8") as f:
+            logs = f.read()
+        pytest.fail(f"Server failed to start and respond after {max_retries} seconds. Logs:\n{logs}")
     
     yield process
     


### PR DESCRIPTION
The previous merge of #181 happened just before the final stability fix could be included. This PR re-applies the dynamic health check for the system test to prevent flakiness in CI.

Changes:
- Replaces fixed `time.sleep(10)` with a 30-second dynamic health check loop in `tests/system/test_server_http.py`.
- Includes diagnostic log output on failure.