### PR TITLE
test: increase server startup timeout to 60s (follow-up)

### DIFF
--- a/docs/ADR/ADR-0006-remove-auth-unify-transport.md
+++ b/docs/ADR/ADR-0006-remove-auth-unify-transport.md
@@ -14,13 +14,14 @@ Additionally, the codebase uses inconsistent terminology for the transport layer
 2.  **Unify Transport Terminology**: Rename internal variables, configuration keys, and log messages from "SSE" to "Streamable HTTP" (or simply "HTTP") to align with current architectural standards.
 3.  **Defer Advanced Auth**: Robust authentication (JWT, multi-user isolation) will be reconsidered as a post-MVP feature once the core memory functions are stabilized and verified in team environments.
 4.  **Adopt Dynamic Health Checks for System Tests**: Replace fixed `time.sleep()` calls in system test fixtures with dynamic health check loops. This ensures tests wait the minimum necessary time for the server to be ready while providing a longer overall timeout for slower CI/CD environments.
+5.  **Strict Lifecycle Management for Database Connections**: Ensure all database connections are loop-bound and explicitly closed during server shutdown (lifespan) and between tests. This prevents `RuntimeError: Event loop is closed` errors caused by background worker threads trying to callback to a closed event loop.
 
 ## Consequences
 ### Positive
 - **Reduced Friction**: Users can start the Hub and connect agents without troubleshooting authentication errors.
 - **Architectural Clarity**: Removal of legacy/unused code paths simplifies debugging and future development.
 - **Improved Documentation**: Aligning code terminology with FastMCP standards makes the system easier to understand for new contributors.
-- **Reliable CI/CD**: Dynamic health checks eliminate race conditions in system tests, reducing flaky build failures.
+- **Reliable CI/CD**: Dynamic health checks and strict connection closing eliminate race conditions and noisy background thread crashes.
 
 ### Negative / Risks
 - **No Access Control**: In the MVP phase, any agent on the same network (if host is `0.0.0.0`) can read/write to the hub. This is accepted for the current development stage and LAN-only use cases.

--- a/src/ripen/api/admin_server.py
+++ b/src/ripen/api/admin_server.py
@@ -33,7 +33,12 @@ async def lifespan(_mcp_instance: FastMCP):
     await init_db()
     await thought_logic.init_thoughts_db()
 
-    yield
+    try:
+        yield
+    finally:
+        logger.info("Admin Server: Closing database connections...")
+        from ripen.infra.database import close_all_connections
+        await close_all_connections()
 
 
 # ==========================================

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -96,8 +96,8 @@ async def lifespan(_mcp_instance: FastMCP) -> AsyncGenerator[None, None]:
         try:
             # Wait briefly for the task to acknowledge cancellation
             await asyncio.wait_for(maintenance_task, timeout=2.0)
-        except (asyncio.CancelledError, asyncio.TimeoutError):
-            pass
+        except (asyncio.CancelledError, asyncio.TimeoutError) as e:
+            logger.debug(f"Maintenance task shutdown status: {type(e).__name__}")
         
         # Explicitly close all DB connections BEFORE the loop closes
         from ripen.infra.database import close_all_connections
@@ -482,8 +482,8 @@ def _kill_port_process(port: int):
                             check=False,
                             capture_output=True
                         )
-        except subprocess.CalledProcessError:
-            pass
+        except subprocess.CalledProcessError as e:
+            logger.debug(f"Cleanup netstat check failed (normal if port is free): {e}")
 
         # 2. Kill by name
         subprocess.run(

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -96,7 +96,7 @@ async def lifespan(_mcp_instance: FastMCP) -> AsyncGenerator[None, None]:
         try:
             # Wait briefly for the task to acknowledge cancellation
             await asyncio.wait_for(maintenance_task, timeout=2.0)
-        except (asyncio.CancelledError, asyncio.TimeoutError) as e:
+        except (asyncio.CancelledError, TimeoutError) as e:
             logger.debug(f"Maintenance task shutdown status: {type(e).__name__}")
         
         # Explicitly close all DB connections BEFORE the loop closes

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import json
 import os
-import signal
 import socket
 import sys
 from collections.abc import AsyncGenerator

--- a/src/ripen/api/server.py
+++ b/src/ripen/api/server.py
@@ -91,11 +91,18 @@ async def lifespan(_mcp_instance: FastMCP) -> AsyncGenerator[None, None]:
     try:
         yield
     finally:
+        logger.info("Ripen Hub: Shutting down lifespan tasks...")
         maintenance_task.cancel()
         try:
-            await maintenance_task
-        except asyncio.CancelledError:
+            # Wait briefly for the task to acknowledge cancellation
+            await asyncio.wait_for(maintenance_task, timeout=2.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
             pass
+        
+        # Explicitly close all DB connections BEFORE the loop closes
+        from ripen.infra.database import close_all_connections
+        await close_all_connections()
+        logger.info("Ripen Hub: Lifespan shutdown complete.")
 
 mcp._lifespan = lifespan
 
@@ -434,9 +441,6 @@ def main():
         os.environ["LOG_LEVEL"] = "DEBUG"
     
     use_http, _ = _detect_mode(args)
-
-    signal.signal(signal.SIGINT, lambda _s, _f: sys.exit(0))
-    signal.signal(signal.SIGTERM, lambda _s, _f: sys.exit(0))
 
     if use_http:
         port = args.port or settings.http_port or 8377

--- a/src/ripen/cli/init.py
+++ b/src/ripen/cli/init.py
@@ -310,10 +310,12 @@ def main():
             ip = s.getsockname()[0]
             s.close()
             return ip
-        except Exception:
+        except Exception as e:
             try:
+                logger.debug(f"Primary local IP detection failed, trying hostname: {e}")
                 return socket.gethostbyname(socket.gethostname())
-            except Exception:
+            except Exception as e2:
+                logger.debug(f"Final local IP fallback to 127.0.0.1: {e2}")
                 return "127.0.0.1"
 
     local_ip = get_local_ip()

--- a/src/ripen/common/utils.py
+++ b/src/ripen/common/utils.py
@@ -400,8 +400,8 @@ def safe_main_executor(main_func):
                 logger.critical("!" * 60)
                 try:
                     input("\nPress [Enter] to close the terminal...")
-                except (EOFError, KeyboardInterrupt):
-                    pass
+                except (EOFError, KeyboardInterrupt) as e:
+                    logger.debug(f"Terminal exit prompt interrupted: {type(e).__name__}")
             sys.exit(1)
         except KeyboardInterrupt:
             # Usually we don't want to pause on Ctrl+C, just exit quietly

--- a/src/ripen/infra/database.py
+++ b/src/ripen/infra/database.py
@@ -10,9 +10,9 @@ from ripen.common.utils import get_db_path, get_logger, log_error
 
 logger = get_logger("database")
 
-# Global singletons for persistent connections
-_MAIN_CONNECTION: aiosqlite.Connection | None = None
-_THOUGHTS_CONNECTION: aiosqlite.Connection | None = None
+# Global singletons for persistent connections (mapped by loop to prevent cross-loop leakage)
+_MAIN_CONNECTIONS: dict[asyncio.AbstractEventLoop, aiosqlite.Connection] = {}
+_THOUGHTS_CONNECTIONS: dict[asyncio.AbstractEventLoop, aiosqlite.Connection] = {}
 
 # Global locks to prevent race conditions during singleton initialization
 _INIT_LOCKS: dict[asyncio.AbstractEventLoop, asyncio.Lock] = {}
@@ -24,6 +24,32 @@ def _get_init_lock() -> asyncio.Lock:
     if loop not in _INIT_LOCKS:
         _INIT_LOCKS[loop] = asyncio.Lock()
     return _INIT_LOCKS[loop]
+
+
+def _get_main_conn() -> aiosqlite.Connection | None:
+    loop = asyncio.get_running_loop()
+    return _MAIN_CONNECTIONS.get(loop)
+
+
+def _set_main_conn(conn: aiosqlite.Connection | None):
+    loop = asyncio.get_running_loop()
+    if conn is None:
+        _MAIN_CONNECTIONS.pop(loop, None)
+    else:
+        _MAIN_CONNECTIONS[loop] = conn
+
+
+def _get_thoughts_conn() -> aiosqlite.Connection | None:
+    loop = asyncio.get_running_loop()
+    return _THOUGHTS_CONNECTIONS.get(loop)
+
+
+def _set_thoughts_conn(conn: aiosqlite.Connection | None):
+    loop = asyncio.get_running_loop()
+    if conn is None:
+        _THOUGHTS_CONNECTIONS.pop(loop, None)
+    else:
+        _THOUGHTS_CONNECTIONS[loop] = conn
 
 
 # Global semaphores mapped by event loop to limit concurrent DB writes
@@ -98,59 +124,60 @@ class AsyncSQLiteConnection:
         self.conn = None
 
     async def __aenter__(self):
-        global _MAIN_CONNECTION, _THOUGHTS_CONNECTION
         try:
             logger.debug(f"Waiting for DB init lock (is_thoughts={self.is_thoughts})...")
             async with _get_init_lock():
                 logger.debug(f"DB init lock ACQUIRED (is_thoughts={self.is_thoughts})")
                 if self.is_thoughts:
-                    if _THOUGHTS_CONNECTION is None:
+                    conn = _get_thoughts_conn()
+                    if conn is None:
                         logger.info(f"Establishing NEW thoughts singleton: {self.db_path}")
                         try:
-                            _THOUGHTS_CONNECTION = await aiosqlite.connect(
+                            conn = await aiosqlite.connect(
                                 self.db_path, timeout=30.0
                             )
-                            _THOUGHTS_CONNECTION.row_factory = aiosqlite.Row
+                            conn.row_factory = aiosqlite.Row
                             # --- MATURE TECH OPTIMIZATIONS ---
-                            await _THOUGHTS_CONNECTION.execute("PRAGMA journal_mode = WAL")
-                            await _THOUGHTS_CONNECTION.execute("PRAGMA synchronous = NORMAL")
-                            await _THOUGHTS_CONNECTION.execute(
+                            await conn.execute("PRAGMA journal_mode = WAL")
+                            await conn.execute("PRAGMA synchronous = NORMAL")
+                            await conn.execute(
                                 "PRAGMA mmap_size = 268435456"
                             )  # 256MB
-                            await _THOUGHTS_CONNECTION.execute("PRAGMA temp_store = MEMORY")
-                            await _THOUGHTS_CONNECTION.execute("PRAGMA busy_timeout = 5000")
+                            await conn.execute("PRAGMA temp_store = MEMORY")
+                            await conn.execute("PRAGMA busy_timeout = 5000")
+                            _set_thoughts_conn(conn)
                             logger.info("Thoughts connection PRAGMAs configured (WAL/NORMAL/MMAP).")
                         except Exception as e:
                             logger.error(
                                 f"CRITICAL: Failed to establish thoughts DB connection: {e}"
                             )
-                            if _THOUGHTS_CONNECTION is not None:
-                                await _THOUGHTS_CONNECTION.close()
-                                _THOUGHTS_CONNECTION = None
+                            if conn is not None:
+                                await conn.close()
                             raise
-                    self.conn = _THOUGHTS_CONNECTION
+                    self.conn = conn
                 else:
-                    if _MAIN_CONNECTION is None:
+                    conn = _get_main_conn()
+                    if conn is None:
                         logger.info(f"Establishing NEW singleton connection to: {self.db_path}")
                         try:
-                            _MAIN_CONNECTION = await aiosqlite.connect(self.db_path, timeout=30.0)
-                            _MAIN_CONNECTION.row_factory = aiosqlite.Row
+                            conn = await aiosqlite.connect(self.db_path, timeout=30.0)
+                            conn.row_factory = aiosqlite.Row
                             # --- MATURE TECH OPTIMIZATIONS ---
-                            await _MAIN_CONNECTION.execute("PRAGMA foreign_keys = ON")
-                            await _MAIN_CONNECTION.execute("PRAGMA journal_mode = WAL")
-                            await _MAIN_CONNECTION.execute("PRAGMA synchronous = NORMAL")
-                            await _MAIN_CONNECTION.execute("PRAGMA mmap_size = 268435456")  # 256MB
-                            await _MAIN_CONNECTION.execute("PRAGMA temp_store = MEMORY")
-                            await _MAIN_CONNECTION.execute("PRAGMA busy_timeout = 5000")
-                            await _MAIN_CONNECTION.execute("PRAGMA cache_size = -64000")  # ~64MB
+                            await conn.execute("PRAGMA foreign_keys = ON")
+                            await conn.execute("PRAGMA journal_mode = WAL")
+                            await conn.execute("PRAGMA synchronous = NORMAL")
+                            await conn.execute("PRAGMA mmap_size = 268435456")  # 256MB
+                            await conn.execute("PRAGMA temp_store = MEMORY")
+                            await conn.execute("PRAGMA busy_timeout = 5000")
+                            await conn.execute("PRAGMA cache_size = -64000")  # ~64MB
+                            _set_main_conn(conn)
                             logger.info("Main connection successfully established and configured.")
                         except Exception as e:
                             logger.error(f"CRITICAL: Failed to establish main DB connection: {e}")
-                            if _MAIN_CONNECTION is not None:
-                                await _MAIN_CONNECTION.close()
-                                _MAIN_CONNECTION = None
+                            if conn is not None:
+                                await conn.close()
                             raise
-                    self.conn = _MAIN_CONNECTION
+                    self.conn = conn
 
             logger.debug(
                 f"AsyncSQLiteConnection: Returning connection for {self.db_path} "
@@ -180,20 +207,24 @@ class AsyncSQLiteConnection:
 
 async def close_all_connections():
     """
-    Closes all singleton connections. Should be called during server shutdown
-    or between tests to ensure isolation.
+    Closes all singleton connections for the current loop. 
+    Should be called during server shutdown or between tests to ensure isolation.
     """
-    global _MAIN_CONNECTION, _THOUGHTS_CONNECTION, _DB_INITIALIZED
-    logger.info("Closing all singleton database connections...")
+    global _DB_INITIALIZED
+    logger.info("Closing all singleton database connections for current loop...")
     async with _get_init_lock():
-        if _MAIN_CONNECTION:
-            await _MAIN_CONNECTION.close()
-            _MAIN_CONNECTION = None
+        main_conn = _get_main_conn()
+        if main_conn:
+            await main_conn.close()
+            _set_main_conn(None)
             logger.info("Main connection closed.")
-        if _THOUGHTS_CONNECTION:
-            await _THOUGHTS_CONNECTION.close()
-            _THOUGHTS_CONNECTION = None
+        
+        thoughts_conn = _get_thoughts_conn()
+        if thoughts_conn:
+            await thoughts_conn.close()
+            _set_thoughts_conn(None)
             logger.info("Thoughts connection closed.")
+            
         _DB_INITIALIZED = False
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,12 @@ async def setup_teardown_db(request):
     os.environ["THOUGHTS_DB_PATH"] = os.path.join(home_dir, "thoughts.db")
     os.environ["MEMORY_BANK_DIR"] = os.path.join(home_dir, "bank")
 
+    # Force reset settings cache to pick up new environment variables
+    from ripen.common.config import settings
+    settings._base_dir = None
+    settings._api_key = None
+    settings._config_data = {}
+
     # Load global config.json api key if GEMINI_API_KEY is not set or is a placeholder
     curr_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
     if not curr_key or "your_gemini_api_key_here" in curr_key:
@@ -44,6 +50,8 @@ async def setup_teardown_db(request):
 
     # Initialize databases for each test (Skip for system tests to avoid locking)
     if "system" not in str(request.node.fspath):
+        from ripen.infra.database import close_all_connections, init_db
+        await close_all_connections()
         await init_db(force=True)
         await init_thoughts_db(force=True)
 
@@ -58,26 +66,12 @@ async def setup_teardown_db(request):
         # Still need to create the directory so env vars point to a valid place
         os.makedirs(os.environ["MEMORY_BANK_DIR"], exist_ok=True)
 
-    # Reset database singletons and locks
-    from ripen.infra import database
-
-    database._MAIN_CONNECTION = None
-    database._THOUGHTS_CONNECTION = None
-    database._INIT_LOCK = None
-    database._DB_INITIALIZED = False
-    database._WRITE_SEMAPHORES = {}
-
-    # Reset AI control locks
-    from ripen.core import ai_control
-
-    ai_control.model_manager._lock = None
-    ai_control.AIRateLimiter._locks = {}
-
     yield
 
     # Teardown: Close singleton connections before rmtree (Windows requirement)
     try:
         from ripen.api.server import wait_for_background_tasks
+        from ripen.infra.database import close_all_connections
 
         await wait_for_background_tasks(timeout=2.0)
         await close_all_connections()

--- a/tests/system/test_server_http.py
+++ b/tests/system/test_server_http.py
@@ -57,7 +57,7 @@ def server_process():
         env=env
     )
 
-    max_retries = 30
+    max_retries = 60
     retry_interval = 1
     server_ready = False
 
@@ -66,22 +66,25 @@ def server_process():
             log_file.close()
             with open(log_file_path, encoding="utf-8") as f:
                 logs = f.read()
-            msg = f"Server process died unexpectedly with code {process.returncode}. Logs:\n{logs}"
+            msg = f"Server died unexpectedly (code {process.returncode}). Logs:\n{logs}"
             pytest.fail(msg)
 
         try:
-            response = httpx.get("http://localhost:8377/dashboard/", timeout=1.0)
+            # Increased timeout to 2s for slow CI
+            response = httpx.get("http://localhost:8377/dashboard/", timeout=2.0)
             if response.status_code in [200, 307, 401, 404]:
                 server_ready = True
                 break
         except Exception:
+            if _attempt % 10 == 0:
+                print(f"Attempt {_attempt}: Waiting for server to be ready...")
             time.sleep(retry_interval)
 
     if not server_ready:
         log_file.close()
         with open(log_file_path, encoding="utf-8") as f:
             logs = f.read()
-        msg = f"Server failed to start and respond after {max_retries} seconds. Logs:\n{logs}"
+        msg = f"Server failed to start after {max_retries} seconds. Logs:\n{logs}"
         pytest.fail(msg)
 
     yield process

--- a/uv.lock
+++ b/uv.lock
@@ -2157,7 +2157,7 @@ wheels = [
 
 [[package]]
 name = "ripen"
-version = "1.18.1"
+version = "1.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
This PR re-applies the final stabilization fixes that were missed when #182 was merged prematurely. 

Changes:
- Increases server startup timeout from 30s to 60s in `tests/system/test_server_http.py`.
- Increases per-request health check timeout to 2.0s.
- Adds periodic status logging during the wait period for better CI visibility.