### PR TITLE
feat: Add setup and start scripts for uv environment (#188)

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,44 @@
+@echo off
+setlocal
+pushd "%~dp0"
+
+echo [Ripen] Starting environment setup...
+echo ----------------------------------------
+
+:: Check for uv
+where uv >nul 2>&1
+if %errorlevel% neq 0 (
+    echo [Error] 'uv' is not installed or not in PATH.
+    echo Please install it first: https://github.com/astral-sh/uv
+    pause
+    exit /b 1
+)
+
+:: Create .venv if it doesn't exist
+if not exist .venv (
+    echo [Ripen] Creating virtual environment...
+    uv venv
+    if %errorlevel% neq 0 (
+        echo [Error] Failed to create virtual environment.
+        pause
+        exit /b 1
+    )
+)
+
+:: Install in editable mode
+echo [Ripen] Installing dependencies in editable mode (uv pip install -e .)...
+uv pip install -e .
+
+if %errorlevel% neq 0 (
+    echo [Error] Installation failed.
+    pause
+    exit /b 1
+)
+
+echo.
+echo [Ripen] Setup completed successfully!
+echo You can now start the system using start.bat.
+echo.
+
+popd
+pause

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,27 @@
+@echo off
+setlocal
+pushd "%~dp0"
+
+:: Check for .venv
+if not exist .venv (
+    echo [Error] Virtual environment (.venv) not found.
+    echo Please run setup.bat first to initialize the environment.
+    pause
+    exit /b 1
+)
+
+echo [Ripen] Starting Hub Server...
+echo ----------------------------------------
+
+:: Use uv run to launch the main entry point
+uv run ripen
+
+if %errorlevel% neq 0 (
+    echo.
+    echo [Error] System exited with error code %errorlevel%.
+    pause
+    exit /b 1
+)
+
+popd
+pause


### PR DESCRIPTION
Closes #188

Added `setup.bat` and `start.bat` to simplify environment setup and server startup using `uv`.

### Changes
- `setup.bat`: Interactive script to create `.venv` and install the package in editable mode.
- `start.bat`: Convenience script to launch the Ripen Hub server using `uv run`.

Both scripts are portable and include basic error checking (e.g., verifying `uv` is installed, checking for `.venv`).